### PR TITLE
Type Mismatch

### DIFF
--- a/sentiment.py
+++ b/sentiment.py
@@ -634,7 +634,7 @@ if __name__ == '__main__':
             try:
                 f = open(twitter_users_file, "w")
                 for i in useridlist:
-                    f.write(i + '\n')
+                    f.write(str(i) + '\n')
                 f.close()
             except (IOError, OSError) as e:
                 logger.warning("Exception: error writing to file caused by: %s" % e)


### PR DESCRIPTION
On occasion, we'll get an error as i returns bytes of userids when it should return a str, accounting for it further down to allow for other byte operations to take place earlier if need be